### PR TITLE
Rename PSRemotingTools module, and update with latest CI

### DIFF
--- a/Modules/Microsoft.PowerShell.RemotingTools/.ci/ci.yml
+++ b/Modules/Microsoft.PowerShell.RemotingTools/.ci/ci.yml
@@ -1,0 +1,128 @@
+name: $(BuildDefinitionName)-$(date:yyMM).$(date:dd)$(rev:rrr)
+trigger:
+  # Batch merge builds together while a merge build is running
+  batch: true
+  branches:
+    include:
+    - master
+pr:
+  branches:
+    include:
+    - master
+
+stages:
+- stage: Build
+  displayName: Build and Sign PSRemotingTools Package
+  jobs:
+  - job: BuildPkg
+    displayName: Build and Sign Package
+    pool:
+      name: Package ES CodeHub Lab E
+    steps:
+    - powershell: |
+        $powerShellPath = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath 'powershell'
+        Invoke-WebRequest -Uri https://raw.githubusercontent.com/PowerShell/PowerShell/master/tools/install-powershell.ps1 -outfile ./install-powershell.ps1
+        ./install-powershell.ps1 -Destination $powerShellPath
+        $vstsCommandString = "vso[task.setvariable variable=PATH]$powerShellPath;$env:PATH"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
+      displayName: Install PowerShell Core
+
+    - task: PkgESSetupBuild@10
+      displayName: 'Package ES - Setup Build'
+      inputs:
+        productName: PSRemotingTools
+        useDfs: false
+
+    - pwsh: |
+        Get-ChildItem -Path env:
+      displayName: Capture environment for build
+      condition: succeededOrFailed()
+
+    - pwsh: |
+        Install-Module -Name "platyPS","Pester" -Force
+      displayName: Install dependencies
+    - pwsh: |
+        Install-Module -Name "PSScriptAnalyzer" -RequiredVersion 1.18.0 -Force
+      displayName: Install PSScriptAnalyzer
+    - pwsh: |
+        Install-Module -Name PSPackageProject -Force
+      displayName: Install PSPackageProject module
+    - pwsh: |
+        $(Build.SourcesDirectory)/build.ps1 -Build
+      displayName: Build and publish artifact
+
+    - pwsh: |
+        Install-Module -Name PSPackageProject -Force
+        $config = Get-PSPackageProjectConfiguration
+        $signSrcPath = "$($config.BuildOutputPath)\$($config.ModuleName)"
+        $signOutPath = "$($config.BuildOutputPath)\$($config.ModuleName)\Signed"
+        if (! (Test-Path -Path $signOutPath)) {
+          $null = New-Item -Path $signOutPath -ItemType Directory
+        }
+        $vstsCommandString = "vso[task.setvariable variable=signSrcPath]${signSrcPath}"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
+        $vstsCommandString = "vso[task.setvariable variable=signOutPath]${signOutPath}"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
+        $vstsCommandString = "vso[task.setvariable variable=signXmlPath]$($config.SourcePath)\..\sign-module-files.xml"
+        Write-Host "sending " + $vstsCommandString
+        Write-Host "##$vstsCommandString"
+      displayName: Set up for code signing
+
+    - pwsh: |
+        Get-ChildItem -Path env:
+      displayName: Capture environment for code signing
+      condition: succeededOrFailed()
+
+    - task: PkgESCodeSign@10
+      displayName: Sign build files
+      env:
+        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      inputs:
+        signConfigXml: '$(signXmlPath)'
+        inPathRoot: '$(signSrcPath)'
+        outPathRoot: '$(signOutPath)'
+        binVersion: Production
+        binVersionOverride: ''
+      condition: and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), ne(variables['SkipSigning'], 'True'))
+
+- stage: Compliance
+  displayName: Compliance
+  dependsOn: Build
+  jobs:
+  - job: ComplianceJob
+    pool:
+      name: Package ES CodeHub Lab E
+    steps:
+    - template: compliance.yml
+
+- stage: Test
+  displayName: Test Package
+  dependsOn: Build
+  jobs:
+  - template: test.yml
+    parameters:
+      jobName: TestPkgWin
+      displayName: PowerShell Core on Windows
+      imageName: windows-2019
+
+  - template: test.yml
+    parameters:
+      jobName: TestPkgUbuntu16
+      displayName: PowerShell Core on Ubuntu 16.04
+      imageName: ubuntu-16.04
+
+  - template: test.yml
+    parameters:
+      jobName: TestPkgWinMacOS
+      displayName: PowerShell Core on macOS
+      imageName: macOS-10.14
+
+- stage: Release
+  displayName: Release Package
+  condition: and(and(succeeded(), eq(variables['Build.Reason'], 'Manual')), eq(variables['Publish'], 'True'))
+  jobs:
+  - template: release.yml
+  

--- a/Modules/Microsoft.PowerShell.RemotingTools/.ci/compliance.yml
+++ b/Modules/Microsoft.PowerShell.RemotingTools/.ci/compliance.yml
@@ -1,0 +1,58 @@
+steps:
+
+- task: DownloadBuildArtifacts@0
+  displayName: 'Download artifacts'
+  inputs:
+    buildType: current
+    downloadType: specifc
+    itemPattern: '**/*.nupkg'
+    downloadPath: '$(System.ArtifactsDirectory)'
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
+  displayName: 'Run Defender Scan'
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+  displayName: 'Run CredScan'
+  inputs:
+    debugMode: false
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  displayName: 'Run PoliCheck'
+  inputs:
+    targetType: F
+    optionsFC: 0
+    optionsXS: 0
+    optionsPE: '1|2|3|4'
+    optionsHMENABLE: 0
+#      optionsRulesDBPath: '$(Build.SourcesDirectory)\tools\terms\PowerShell-Terms-Rules.mdb'
+#      optionsFTPATH: '$(Build.SourcesDirectory)\tools\terms\FileTypeSet.xml'
+    toolVersion: 5.8.2.1
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  displayName: 'Publish Security Analysis Logs to Build Artifacts'
+  continueOnError: true
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@1
+  displayName: 'TSA upload to Codebase: PSRemotingTools_202001 Stamp: Azure'
+  inputs:
+    codeBaseName: PSRemotingTools_202001
+    tsaVersion: TsaV2
+    uploadFortifySCA: false
+    uploadFxCop: false
+    uploadModernCop: false
+    uploadPREfast: false
+    uploadRoslyn: false
+    uploadTSLint: false
+    uploadAPIScan: false
+
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-report.SdtReport@1
+  displayName: 'Create Security Analysis Report'
+  inputs:
+    TsvFile: false
+    APIScan: false
+    BinSkim: false
+    CredScan: true
+    PoliCheck: true
+    PoliCheckBreakOn: Severity2Above

--- a/Modules/Microsoft.PowerShell.RemotingTools/.ci/release.yml
+++ b/Modules/Microsoft.PowerShell.RemotingTools/.ci/release.yml
@@ -1,0 +1,23 @@
+parameters:
+  jobName: release
+  imageName: windows-2019
+  displayName: Release
+
+jobs:
+- job: ${{ parameters.jobName }}
+  pool:
+    vmImage: ${{ parameters.imageName }}
+  displayName: ${{ parameters.displayName }}
+  steps:
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download artifacts'
+    inputs:
+      buildType: current
+      downloadType: single
+      artifactName: NuPkg
+      downloadPath: '$(System.ArtifactsDirectory)'
+  - task: NuGetToolInstaller@1
+    displayName: 'Install NuGet'
+  - pwsh: |
+        nuget push $(System.ArtifactsDirectory)\nupkg\*.nupkg -ApiKey $(NuGetApiKey) -Source https://www.powershellgallery.com/api/v2/package/ -NonInteractive
+    displayName: Publish Package

--- a/Modules/Microsoft.PowerShell.RemotingTools/.ci/test.yml
+++ b/Modules/Microsoft.PowerShell.RemotingTools/.ci/test.yml
@@ -1,0 +1,57 @@
+parameters:
+  jobName: TestPkgWin
+  imageName: windows-2019
+  displayName: PowerShell Core on Windows
+  powershellExecutable: pwsh
+
+jobs:
+- job: ${{ parameters.jobName }}
+  pool:
+    vmImage: ${{ parameters.imageName }}
+  displayName: ${{ parameters.displayName }}
+  steps:
+  - ${{ parameters.powershellExecutable }}: |
+      Install-Module -Name "platyPS","Pester" -Force
+    displayName: Install dependencies
+
+  - ${{ parameters.powershellExecutable }}: |
+        Install-Module -Name "PSScriptAnalyzer" -RequiredVersion 1.18.0 -Force
+    displayName: Install dependencies
+
+  - ${{ parameters.powershellExecutable }}: |
+      Install-Module -Name PSPackageProject -Force
+    displayName: Install PSPackageProject module
+
+  - task: DownloadBuildArtifacts@0
+    displayName: 'Download artifacts'
+    inputs:
+      buildType: current
+      downloadType: specific
+      itemPattern: '**/*.nupkg'
+      downloadPath: '$(System.ArtifactsDirectory)'
+
+  - ${{ parameters.powershellExecutable }}: |
+      $sourceName = 'pspackageproject-local-repo'
+      Register-PSRepository -Name $sourceName -SourceLocation '$(System.ArtifactsDirectory)' -ErrorAction Ignore
+      $config = Get-PSPackageProjectConfiguration
+      $buildOutputPath = $config.BuildOutputPath
+      $null = New-Item -ItemType Directory -Path $buildOutputPath -Verbose
+      $moduleName = $config.ModuleName
+      Save-Module -Repository $sourceName -Name $moduleName -Path $config.BuildOutputPath
+    displayName: Extract product artifact
+
+  - ${{ parameters.powershellExecutable }}: |
+      Invoke-PSPackageProjectTest -Type Functional
+    displayName: Execute functional tests
+    errorActionPreference: continue
+
+#  - ${{ parameters.powershellExecutable }}: |
+#      Invoke-PSPackageProjectTest -Type StaticAnalysis
+#    displayName: Execute static analysis tests
+#    errorActionPreference: continue
+#    condition: succeededOrFailed()
+
+  - ${{ parameters.powershellExecutable }}: |
+      Unregister-PSRepository -Name 'pspackageproject-local-repo' -ErrorAction Ignore
+    displayName: Unregister temporary PSRepository
+    condition: always()

--- a/Modules/Microsoft.PowerShell.RemotingTools/README.md
+++ b/Modules/Microsoft.PowerShell.RemotingTools/README.md
@@ -1,0 +1,31 @@
+This module contains remoting tool cmdlets.
+
+## EnableSSHRemoting
+
+PowerShell SSH remoting was implemented in PowerShell 6.0 but requries SSH (client) and SSHD (service) components to be installed.
+In addition the sshd_config configuration file must be updated to define a PowerShell endpoint as a subsystem.
+Once this is done PowerShell remoting cmdlets can be used to establish a PowerShell remoting session over SSH that works across platforms. 
+
+```powershell
+$session = New-PSSession -HostName LinuxComputer1 -UserName UserA -SSHTransport
+```
+
+There are a number of requirements that must be satisfied for PowerShell SSH based remoting:
+
+- PowerShell 6.0 or greater must be installed on the system.
+Since multiple PowerShell installations can appear on a single system, a specific installation can be selected.
+- SSH client must be installed on the system as PowerShell uses it for outgoing connections.
+- SSHD (ssh daemon) must be installed on the system for PowerShell to receive SSH connections.
+- SSHD must be configured with a Subsystem that serves as the PowerShell remoting endpoint.
+
+This module exports a single cmdlet: Enable-SSHRemoting
+
+The Enable-SSHRemoting cmdlet will do the following:
+
+- Detect the underlying platform (Windows, Linux, macOS).
+- Detect an installed SSH client, and emit a warning if not found.
+- Detect an installed SSHD daemon, and emit a warning if not found.
+- Accept a PowerShell (pwsh) path to be run as a remoting PowerShell session endpoint, or try to use the currently running PowerShell.
+- Update the SSHD configuration file to add a PowerShell subsystem endpoint entry.
+
+If all of the conditions are satisfied then PowerShell SSH remoting will work to and from the local system.

--- a/Modules/Microsoft.PowerShell.RemotingTools/build.ps1
+++ b/Modules/Microsoft.PowerShell.RemotingTools/build.ps1
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+param (
+    [Parameter(ParameterSetName="build")]
+    [switch]
+    $Clean,
+
+    [Parameter(ParameterSetName="build")]
+    [switch]
+    $Build,
+
+    [Parameter(ParameterSetName="build")]
+    [switch]
+    $Test,
+
+    [Parameter(ParameterSetName="build")]
+    [string[]]
+    [ValidateSet("Functional","StaticAnalysis")]
+    $TestType = @("Functional"),
+
+    [Parameter(ParameterSetName="help")]
+    [switch]
+    $UpdateHelp
+)
+
+$config = Get-PSPackageProjectConfiguration -ConfigPath $PSScriptRoot
+
+$script:ModuleName = $config.ModuleName
+$script:SrcPath = $config.SourcePath
+$script:OutDirectory = $config.BuildOutputPath
+$script:TestPath = $config.TestPath
+
+$script:ModuleRoot = $PSScriptRoot
+$script:Culture = $config.Culture
+$script:HelpPath = $config.HelpPath
+
+<#
+.DESCRIPTION
+Implement build and packaging of the package and place the output $OutDirectory/$ModuleName
+#>
+function DoBuild
+{
+    Write-Verbose -Verbose -Message "Starting DoBuild"
+
+    Write-Verbose -Verbose -Message "Copying module files to '${OutDirectory}/${ModuleName}'"
+    # copy psm1 and psd1 files
+    copy-item "${SrcPath}/${ModuleName}.psd1" "${OutDirectory}/${ModuleName}"
+    copy-item "${SrcPath}/${ModuleName}.psm1" "${OutDirectory}/${ModuleName}"
+    # copy format files here
+    #
+
+    # copy help
+    Write-Verbose -Verbose -Message "Copying help files to '${OutDirectory}/${ModuleName}'"
+    copy-item -Recurse "${HelpPath}/${Culture}" "${OutDirectory}/${ModuleName}"
+
+    # There is no code path, this is a PowerShell script module
+    if ( Test-Path "${SrcPath}/code" ) {
+        Write-Verbose -Verbose -Message "Building assembly and copying to '${OutDirectory}/${ModuleName}'"
+        # build code and place it in the staging location
+        try {
+            Push-Location "${SrcPath}/code"
+            $result = dotnet publish
+            copy-item "bin/Debug/netstandard2.0/publish/${ModuleName}.dll" "${OutDirectory}/${ModuleName}"
+        }
+        catch {
+            $result | ForEach-Object { Write-Warning $_ }
+            Write-Error "dotnet build failed"
+        }
+        finally {
+            Pop-Location
+        }
+    }
+    else {
+        Write-Verbose -Verbose -Message "No code to build in '${SrcPath}/code'"
+    }
+
+    ## Add build and packaging here
+    Write-Verbose -Verbose -Message "Ending DoBuild"
+}
+
+if ( ! ( Get-Module -ErrorAction SilentlyContinue PSPackageProject) ) {
+    Install-Module PSPackageProject
+}
+
+if ($Clean -and (Test-Path $OutDirectory))
+{
+    Remove-Item -Force -Recurse $OutDirectory -ErrorAction Stop -Verbose
+}
+
+if (-not (Test-Path $OutDirectory))
+{
+    $script:OutModule = New-Item -ItemType Directory -Path (Join-Path $OutDirectory $ModuleName)
+}
+else
+{
+    $script:OutModule = Join-Path $OutDirectory $ModuleName
+}
+
+if ($Build.IsPresent)
+{
+    $sb = (Get-Item Function:DoBuild).ScriptBlock
+    Invoke-PSPackageProjectBuild -BuildScript $sb
+}
+
+if ( $Test.IsPresent ) {
+    Invoke-PSPackageProjectTest -Type $TestType
+}
+
+if ($UpdateHelp.IsPresent) {
+    Add-PSPackageProjectCmdletHelp -ProjectRoot $ModuleRoot -ModuleName $ModuleName -Culture $Culture
+}

--- a/Modules/Microsoft.PowerShell.RemotingTools/help/en-US/about_Microsoft.PowerShell.RemotingTools.md
+++ b/Modules/Microsoft.PowerShell.RemotingTools/help/en-US/about_Microsoft.PowerShell.RemotingTools.md
@@ -1,0 +1,57 @@
+# Microsoft.PSRemotingTools
+## about_Microsoft.PSRemotingTools
+
+```
+ABOUT TOPIC NOTE:
+The first header of the about topic should be the topic name.
+The second header contains the lookup name used by the help system.
+
+IE:
+# Some Help Topic Name
+## SomeHelpTopicFileName
+
+This will be transformed into the text file
+as `about_SomeHelpTopicFileName`.
+Do not include file extensions.
+The second header should have no spaces.
+```
+
+# SHORT DESCRIPTION
+{{ Short Description Placeholder }}
+
+```
+ABOUT TOPIC NOTE:
+About topics can be no longer than 80 characters wide when rendered to text.
+Any topics greater than 80 characters will be automatically wrapped.
+The generated about topic will be encoded UTF-8.
+```
+
+# LONG DESCRIPTION
+{{ Long Description Placeholder }}
+
+## Optional Subtopics
+{{ Optional Subtopic Placeholder }}
+
+# EXAMPLES
+{{ Code or descriptive examples of how to leverage the functions described. }}
+
+# NOTE
+{{ Note Placeholder - Additional information that a user needs to know.}}
+
+# TROUBLESHOOTING NOTE
+{{ Troubleshooting Placeholder - Warns users of bugs}}
+
+{{ Explains behavior that is likely to change with fixes }}
+
+# SEE ALSO
+{{ See also placeholder }}
+
+{{ You can also list related articles, blogs, and video URLs. }}
+
+# KEYWORDS
+{{List alternate names or titles for this topic that readers might use.}}
+
+- {{ Keyword Placeholder }}
+- {{ Keyword Placeholder }}
+- {{ Keyword Placeholder }}
+- {{ Keyword Placeholder }}

--- a/Modules/Microsoft.PowerShell.RemotingTools/pspackageproject.json
+++ b/Modules/Microsoft.PowerShell.RemotingTools/pspackageproject.json
@@ -1,0 +1,9 @@
+{
+  "BuildOutputPath": "out",
+  "ModuleName": "Microsoft.PowerShell.RemotingTools",
+  "TestPath": "test",
+  "Culture": "en-US",
+  "HelpPath": "help",
+  "SourcePath": "src",
+  "SignedOutputPath": "signed"
+}

--- a/Modules/Microsoft.PowerShell.RemotingTools/sign-module-files.xml
+++ b/Modules/Microsoft.PowerShell.RemotingTools/sign-module-files.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<!-- Config files for Azure DevOps code-signing pipeline. -->
+<SignConfigXML>
+  <job platform="" configuration="" dest="__OUTPATHROOT__\signed" jobname="PSRemotingTools" approvers="vigarg;gstolt">
+    <file src="__INPATHROOT__\Microsoft.PowerShell.RemotingTools.psd1" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\Microsoft.PowerShell.RemotingTools.psd1" />
+    <file src="__INPATHROOT__\Microsoft.PowerShell.RemotingTools.psm1" signType="AuthenticodeFormer" dest="__OUTPATHROOT__\Microsoft.PowerShell.RemotingTools.psm1" />
+  </job>
+</SignConfigXML>

--- a/Modules/Microsoft.PowerShell.RemotingTools/src/Microsoft.PowerShell.RemotingTools.psd1
+++ b/Modules/Microsoft.PowerShell.RemotingTools/src/Microsoft.PowerShell.RemotingTools.psd1
@@ -1,0 +1,50 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+@{
+
+RootModule = './Microsoft.PowerShell.RemotingTools.psm1'
+
+ModuleVersion = '0.1.0'
+
+GUID = 'e11d52a1-d5a0-4e4d-92cd-e87114bf4a5c'
+
+Author = 'Microsoft Corporation'
+CompanyName = 'Microsoft Corporation'
+Copyright = '(c) Microsoft Corporation. All rights reserved.'
+
+Description = '
+This module contains remoting tool cmdlets.
+
+Enable-SSHRemoting cmdlet:
+--------------------------
+PowerShell SSH remoting was implemented in PowerShell 6.0 but requries SSH (client) and SSHD (service) components 
+to be installed.  In addition the sshd_config configuration file must be updated to define a PowerShell endpoint
+as a subsystem.  Once this is done PowerShell remoting cmdlets can be used to establish a PowerShell remoting
+session over SSH that works across platforms.
+
+$session = New-PSSession -HostName LinuxComputer1 -UserName UserA -SSHTransport
+
+There are a number of requirements that must be satisfied for PowerShell SSH based remoting:
+  a. PowerShell 6.0 or greater must be installed on the system.
+       Since multiple PowerShell installations can appear on a single system, a specific installation can be selected.
+  b. SSH client must be installed on the system as PowerShell uses it for outgoing connections.
+  c. SSHD (ssh daemon) must be installed on the system for PowerShell to receive SSH connections.
+  d. SSHD must be configured with a Subsystem that serves as the PowerShell remoting endpoint.
+
+The Enable-SSHRemoting cmdlet will do the following:
+  a. Detect the underlying platform (Windows, Linux, macOS).
+  b. Detect an installed SSH client, and emit a warning if not found.
+  c. Detect an installed SSHD daemon, and emit a warning if not found.
+  d. Accept a PowerShell (pwsh) path to be run as a remoting PowerShell session endpoint.
+       Or try to use the currently running PowerShell.
+  e. Update the SSHD configuration file to add a PowerShell subsystem endpoint entry.
+
+If all of the conditions are satisfied then PowerShell SSH remoting will work to and from the local system.
+'
+
+PowerShellVersion = '6.0'
+
+FunctionsToExport = 'Enable-SSHRemoting'
+
+}

--- a/Modules/Microsoft.PowerShell.RemotingTools/src/Microsoft.PowerShell.RemotingTools.psm1
+++ b/Modules/Microsoft.PowerShell.RemotingTools/src/Microsoft.PowerShell.RemotingTools.psm1
@@ -1,0 +1,506 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+##
+## Enable-SSHRemoting Cmdlet
+##
+
+class PlatformInfo
+{
+    [bool] $isCoreCLR
+    [bool] $isLinux
+    [bool] $isOSX
+    [bool] $isWindows
+
+    [bool] $isAdmin
+
+    [bool] $isUbuntu
+    [bool] $isUbuntu14
+    [bool] $isUbuntu16
+    [bool] $isCentOS
+    [bool] $isFedora
+    [bool] $isOpenSUSE
+    [bool] $isOpenSUSE13
+    [bool] $isOpenSUSE42_1
+    [bool] $isRedHatFamily
+}
+
+function DetectPlatform
+{
+    param (
+        [ValidateNotNull()]
+        [PlatformInfo] $PlatformInfo
+    )
+
+    try 
+    {
+        $Runtime = [System.Runtime.InteropServices.RuntimeInformation]
+        $OSPlatform = [System.Runtime.InteropServices.OSPlatform]
+
+        $platformInfo.isCoreCLR = $true
+        $platformInfo.isLinux = $Runtime::IsOSPlatform($OSPlatform::Linux)
+        $platformInfo.isOSX = $Runtime::IsOSPlatform($OSPlatform::OSX)
+        $platformInfo.isWindows = $Runtime::IsOSPlatform($OSPlatform::Windows)
+    } 
+    catch 
+    {
+        $platformInfo.isCoreCLR = $false
+        $platformInfo.isLinux = $false
+        $platformInfo.isOSX = $false
+        $platformInfo.isWindows = $true
+    }
+
+    if ($platformInfo.isWindows)
+    {
+        $platformInfo.isAdmin = ([System.Security.Principal.WindowsPrincipal]::new([System.Security.Principal.WindowsIdentity]::GetCurrent())).IsInRole( `
+            [System.Security.Principal.WindowsBuiltInRole]::Administrator)
+    }
+
+    if ($platformInfo.isLinux)
+    {
+        $LinuxInfo = Get-Content /etc/os-release -Raw | ConvertFrom-StringData
+
+        $platformInfo.isUbuntu = $LinuxInfo.ID -match 'ubuntu'
+        $platformInfo.isUbuntu14 = $platformInfo.isUbuntu -and ($LinuxInfo.VERSION_ID -match '14.04')
+        $platformInfo.isUbuntu16 = $platformInfo.isUbuntu -and ($LinuxInfo.VERSION_ID -match '16.04')
+        $platformInfo.isCentOS = ($LinuxInfo.ID -match 'centos') -and ($LinuxInfo.VERSION_ID -match '7')
+        $platformInfo.isFedora = ($LinuxInfo.ID -match 'fedora') -and ($LinuxInfo.VERSION_ID -ge '24')
+        $platformInfo.isOpenSUSE = $LinuxInfo.ID -match 'opensuse'
+        $platformInfo.isOpenSUSE13 = $platformInfo.isOpenSUSE -and ($LinuxInfo.VERSION_ID -match '13')
+        $platformInfo.isOpenSUSE42_1 = $platformInfo.isOpenSUSE -and ($LinuxInfo.VERSION_ID -match '42.1')
+        $platformInfo.isRedHatFamily = $platformInfo.isCentOS -or $platformInfo.isFedora -or $platformInfo.isOpenSUSE
+    }
+}
+
+class SSHSubSystemEntry
+{
+    [string] $subSystemLine
+    [string] $subSystemName
+    [string] $subSystemCommand
+    [string[]] $subSystemCommandArgs
+}
+
+class SSHRemotingConfig
+{
+    [PlatformInfo] $platformInfo
+    [SSHSubSystemEntry[]] $psSubSystemEntries = @()
+    [string] $configFilePath
+    $configComponents = @()
+
+    SSHRemotingConfig(
+        [PlatformInfo] $platInfo,
+        [string] $configFilePath)
+    {
+        $this.platformInfo = $platInfo
+        $this.configFilePath = $configFilePath
+        $this.ParseSSHRemotingConfig()
+    }
+
+    [string[]] SplitConfigLine([string] $line)
+    {
+        $line = $line.Trim()
+        $lineLength = $line.Length
+        $rtnStrArray = [System.Collections.Generic.List[string]]::new()
+
+        for ($i=0; $i -lt $lineLength; )
+        {
+            $startIndex = $i
+            while (($i -lt $lineLength) -and ($line[$i] -ne " ") -and ($line[$i] -ne "`t")) { $i++ }
+            $rtnStrArray.Add($line.Substring($startIndex, ($i - $startIndex)))
+            while (($i -lt $lineLength) -and ($line[$i] -eq " ") -or ($line[$i] -eq "`t")) { $i++ }
+        }
+
+        return $rtnStrArray.ToArray()
+    }
+
+    ParseSSHRemotingConfig()
+    {
+        [string[]] $contents = Get-Content -Path $this.configFilePath
+        foreach ($line in $contents)
+        {
+            $components = $this.SplitConfigLine($line)
+            $this.configComponents += @{ Line = $line; Components = $components }
+
+            if (($components[0] -eq "Subsystem") -and ($components[1] -eq "powershell"))
+            {
+                $entry = [SSHSubSystemEntry]::New()
+                $entry.subSystemLine = $line
+                $entry.subSystemName = $components[1]
+                $entry.subSystemCommand = $components[2]
+                $entry.subSystemCommandArgs = @()
+                for ($i=3; $i -lt $components.Count; $i++)
+                {
+                    $entry.subSystemCommandArgs += $components[$i]
+                }
+
+                $this.psSubSystemEntries += $entry
+            }
+        }
+    }
+}
+
+function UpdateConfiguration
+{
+    param (
+        [SSHRemotingConfig] $config,
+        [string] $PowerShellPath
+    )
+
+    #
+    # Update and re-write config file with existing settings plus new PowerShell remoting settings
+    #
+
+    # Subsystem
+    [System.Collections.Generic.List[string]] $newContents = [System.Collections.Generic.List[string]]::new()
+    $psSubSystemEntry = "Subsystem       powershell      {0} {1} {2} {3}" -f $powerShellPath, "-SSHS", "-NoProfile", "-NoLogo"
+    $subSystemAdded = $false
+
+    foreach ($lineItem in $config.configComponents)
+    {
+        $line = $lineItem.Line
+        $components = $lineItem.Components
+
+        if ($components[0] -eq "SubSystem")
+        {
+            if (! $subSystemAdded)
+            {
+                # Add new powershell subsystem entry
+                $newContents.Add($psSubSystemEntry)
+                $subSystemAdded = $true
+            }
+
+            if ($components[1] -eq "powershell")
+            {
+                # Remove all existing powershell subsystem entries
+                continue
+            }
+
+            # Include existing subsystem entries.
+            $newContents.Add($line)
+        }
+        else
+        {
+            # Include all other configuration lines
+            $newContents.Add($line)
+        }
+    }
+
+    if (! $subSystemAdded)
+    {
+        $newContents.Add($psSubSystemEntry)
+    }
+
+    # Copy existing file to a backup version
+    $uniqueName = [System.IO.Path]::GetFileNameWithoutExtension([System.IO.Path]::GetRandomFileName())
+    $backupFilePath = $config.configFilePath + "_backup_" + $uniqueName
+    Copy-Item -Path $config.configFilePath -Destination $backupFilePath
+    if ($?)
+    {
+        WriteLine "A backup copy of the old sshd_config configuration file has been created at:"
+        WriteLine $backupFilePath
+    }
+
+    Set-Content -Path $config.configFilePath -Value $newContents.ToArray() -ErrorAction Stop
+}
+
+function CheckPowerShellVersion
+{
+    param (
+        [string] $FilePath
+    )
+
+    if (! (Test-Path $FilePath))
+    {
+        throw "CheckPowerShellVersion failed with invalid path: $FilePath"
+    }
+
+    $commandToExec = "& '$FilePath' -noprofile -noninteractive -c '`$PSVersionTable.PSVersion.Major'"
+    $sb = [scriptblock]::Create($commandToExec)
+
+    $psVersionMajor = 0
+    try
+    {
+        $psVersionMajor = [int] (& $sb) 2>$null
+        Write-Verbose ""
+        Write-Verbose "CheckPowerShellVersion: $psVersionMajor for FilePath: $FilePath"
+    }
+    catch { }
+
+    if ($psVersionMajor -ge 6)
+    {
+        return $true
+    }
+    else
+    {
+        return $false
+    }
+}
+
+function WriteLine
+{
+    param (
+        [string] $Message,
+        [int] $PrependLines = 0,
+        [int] $AppendLines = 0
+    )
+
+    for ($i=0; $i -lt $PrependLines; $i++)
+    {
+        Write-Output ""
+    }
+
+    Write-Output $Message
+
+    for ($i=0; $i -lt $AppendLines; $i++)
+    {
+        Write-Output ""
+    }
+}
+
+# Windows only GetShortPathName PInvoke
+$typeDef = @'
+    using System;
+    using System.Runtime.InteropServices;
+    using System.Text;
+
+    namespace NativeUtils
+    {
+        public class Path
+        {
+            [DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
+            private static extern int GetShortPathName(
+                [MarshalAs(UnmanagedType.LPTStr)]
+                string path,
+                [MarshalAs(UnmanagedType.LPTStr)]
+                StringBuilder shortPath,
+                int shortPathLength);
+
+            public static string ConvertToShortPath(
+                string longPath)
+            {
+                int shortPathLength = 2048;
+                StringBuilder shortPath = new StringBuilder(shortPathLength);
+                GetShortPathName(
+                    path: longPath,
+                    shortPath: shortPath,
+                    shortPathLength: shortPathLength);
+    
+                return shortPath.ToString();
+            }
+        }
+    }
+'@
+
+<#
+.Synopsis
+    Enables PowerShell SSH remoting endpoint on local system
+.Description
+    This cmdlet will set up an SSH based remoting endpoint on the local system, based on
+    the PowerShell executable file path passed in. Or if no PowerShell file path is provided then 
+    the currently running PowerShell file path is used.
+    The end point is enabled by adding a 'powershell' subsystem entry to the SSHD configuration, using
+    the provided or current PowerShell file path.
+    Both the SSH client and SSHD server components are detected and if not found a terminating
+    error is emitted, asking the user to install the components.
+    Then the sshd_config is parsed, and if a new 'powershell' subsystem entry is added.
+.Parameter SSHDConfigFilePath
+    File path to the SSHD service configuration file. This file will be updated to include a
+    'powershell' subsystem entry to define a PowerShell SSH remoting endpoint, so current credentials
+    must have write access to the file.
+.Parameter PowerShellFilePath
+    Specifies the file path to the PowerShell command used to host the SSH remoting PowerShell
+    endpoint. If no value is specified then the currently running PowerShell executable path is used
+    in the subsytem command.
+.Parameter Force
+    When true, this cmdlet will update the sshd_config configuration file without prompting.
+#>
+function Enable-SSHRemoting
+{
+    [CmdletBinding()]
+    param (
+        [string] $SSHDConfigFilePath,
+
+        [string] $PowerShellFilePath,
+
+        [switch] $Force
+    )
+
+    # Detect platform
+    $platformInfo = [PlatformInfo]::new()
+    DetectPlatform $platformInfo
+    Write-Verbose "Platform information"
+    Write-Verbose "$($platformInfo | Out-String)"
+
+    # Non-Windows platforms must run this cmdlet as 'root'
+    if (!$platformInfo.isWindows)
+    {
+        $user = whoami
+        if ($user -ne 'root')
+        {
+            if (! $PSCmdlet.ShouldContinue("This cmdlet must be run as 'root'. If you continue, PowerShell will restart under 'root'. Do you wish to continue?", "Enable-SSHRemoting"))
+            {
+                return
+            }
+
+            # Spawn new PowerShell with sudo and exit this session.
+            $modFilePath = (Get-Module -Name Microsoft.PowerShell.RemotingTools | Select-Object -Property Path).Path
+            $modName = [System.IO.Path]::GetFileNameWithoutExtension($modFilePath)
+            $modFilePath = Join-Path -Path (Split-Path -Path $modFilePath -Parent) -ChildPath "${modName}.psd1"
+
+            $parameters = ""
+            foreach ($key in $PSBoundParameters.Keys)
+            {
+                $parameters += "-${key} "
+                $value = $PSBoundParameters[$key]
+                if ($value -is [string])
+                {
+                    $parameters += "'$value' "
+                }
+            }
+            
+            & sudo "$PSHOME/pwsh" -NoExit -c "Import-Module -Name $modFilePath; Enable-SSHRemoting $parameters"
+            exit
+        }
+    }
+
+    # Detect SSH client installation
+    if (! (Get-Command -Name ssh -ErrorAction SilentlyContinue))
+    {
+        Write-Warning "SSH client is not installed or not discoverable on this machine. SSH client must be installed before PowerShell SSH based remoting can be enabled."
+    }
+
+    # Detect SSHD server installation
+    $SSHDFound = $false
+    if ($platformInfo.IsWindows)
+    {
+        $SSHDFound = $null -ne (Get-Service -Name sshd -ErrorAction SilentlyContinue)
+    }
+    elseif ($platformInfo.IsLinux)
+    {
+        $sshdStatus = systemctl status sshd
+        $SSHDFound = $null -ne $sshdStatus
+    }
+    else
+    {
+        # macOS
+        $SSHDFound = ((launchctl list | Select-String 'com.openssh.sshd') -ne $null)
+    }
+    if (! $SSHDFound)
+    {
+        Write-Warning "SSHD service is not found on this machine. SSHD service must be installed and running before PowerShell SSH based remoting can be enabled."
+    }
+
+    # Validate a SSHD configuration file path
+    if ([string]::IsNullOrEmpty($SSHDConfigFilePath))
+    {
+        Write-Warning "-SSHDConfigFilePath not provided. Using default configuration file location."
+
+        if ($platformInfo.IsWindows)
+        {
+            $SSHDConfigFilePath = Join-Path -Path $env:ProgramData -ChildPath 'ssh' -AdditionalChildPath 'sshd_config'
+        }
+        elseif ($platformInfo.isLinux)
+        {
+            $SSHDConfigFilePath = '/etc/ssh/sshd_config'
+        }
+        else
+        {
+            # macOS
+            $SSHDConfigFilePath = '/private/etc/ssh/sshd_config'
+        }
+    }
+
+    # Validate a PowerShell command to use for endpoint
+    $PowerShellToUse = $PowerShellFilePath
+    if (! [string]::IsNullOrEmpty($PowerShellToUse))
+    {
+        WriteLine "Validating provided -PowerShellFilePath argument." -AppendLines 1 -PrependLines 1
+
+        if (! (Test-Path $PowerShellToUse))
+        {
+            throw "The provided PowerShell file path is invalid: $PowerShellToUse"
+        }
+
+        if (! (CheckPowerShellVersion $PowerShellToUse))
+        {
+            throw "The provided PowerShell file path is an unsupported version of PowerShell.  PowerShell version 6.0 or greater is required."
+        }
+    }
+    else
+    {
+        WriteLine "Validating current PowerShell to use as endpoint subsystem." -AppendLines 1
+
+        # Try currently running PowerShell
+        $PowerShellToUse = Get-Command -Name "$PSHome/pwsh" -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+        if (! $PowerShellToUse -or ! (CheckPowerShellVersion $PowerShellToUse))
+        {
+            throw "Current running PowerShell version is not valid for SSH remoting endpoint. SSH remoting is only supported for PowerShell version 6.0 and higher. Specify a valid PowerShell 6.0+ file path with the -PowerShellFilePath parameter."
+        }
+    }
+
+    # SSHD configuration file uses the space character as a delimiter.
+    # Consequently, the configuration Subsystem entry will not allow argument paths containing space characters.
+    # For Windows platforms, we can a short cut path.
+    # But for non-Windows platforms, we currently throw an error.
+    #   One possible solution is to crete a symbolic link
+    #   New-Item -ItemType SymbolicLink -Path <NewNoSpacesPath> -Value $<PathwithSpaces>
+    if ($PowerShellToUse.Contains(' '))
+    {
+        if ($platformInfo.IsWindows)
+        {
+            Add-Type -TypeDefinition $typeDef
+            $PowerShellToUse = [NativeUtils.Path]::ConvertToShortPath($PowerShellToUse)
+            if (! (Test-Path -Path $PowerShellToUse))
+            {
+                throw "Converting long Windows file path resulted in an invalid path: ${PowerShellToUse}."
+            }
+        }
+        else 
+        {
+            throw "The PowerShell executable (pwsh) selected for hosting the remoting endpoint has a file path containing space characters, which cannot be used with SSHD configuration."
+        }
+    }
+
+    WriteLine "Using PowerShell at this path for SSH remoting endpoint:"
+    WriteLine "$PowerShellToUse" -AppendLines 1
+
+    # Validate the SSHD configuration file path
+    if (! (Test-Path -Path $SSHDConfigFilePath))
+    {
+        throw "The provided SSHDConfigFilePath parameter, $SSHDConfigFilePath, is not a valid path."
+    }
+    WriteLine "Modifying SSHD configuration file at this location:"
+    WriteLine "$SSHDConfigFilePath" -AppendLines 1
+
+    # Get the SSHD configurtion
+    $sshdConfig = [SSHRemotingConfig]::new($platformInfo, $SSHDConfigFilePath)
+
+    if ($sshdConfig.psSubSystemEntries.Count -gt 0)
+    {
+        WriteLine "The following PowerShell subsystems were found in the sshd_config file:"
+        foreach ($entry in $sshdConfig.psSubSystemEntries)
+        {
+            WriteLine $entry.subSystemLine
+        }
+        Writeline "Continuing will overwrite any existing PowerShell subsystem entries with the new subsystem." -PrependLines 1
+        WriteLine "The new SSH remoting endpoint will use this PowerShell executable path:"
+        WriteLine "$PowerShellToUse" -AppendLines 1
+    }
+
+    $shouldContinue = $Force
+    if (! $shouldContinue)
+    {
+        $shouldContinue = $PSCmdlet.ShouldContinue("The SSHD service configuration file (sshd_config) will now be updated to enable PowerShell remoting over SSH. Do you wish to continue?", "Enable-SSHRemoting")
+    }
+
+    if ($shouldContinue)
+    {
+        WriteLine "Updating configuration file ..." -PrependLines 1 -AppendLines 1
+
+        UpdateConfiguration $sshdConfig $PowerShellToUse
+
+        WriteLine "The configuration file has been updated:" -PrependLines 1
+        WriteLine $sshdConfig.configFilePath -AppendLines 1
+        WriteLine "You must restart the SSHD service for the changes to take effect." -AppendLines 1
+    }
+}

--- a/Modules/Microsoft.PowerShell.RemotingTools/test/Microsoft.PowerShell.RemotingTools.Tests.ps1
+++ b/Modules/Microsoft.PowerShell.RemotingTools/test/Microsoft.PowerShell.RemotingTools.Tests.ps1
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+Describe "Test Microsoft.PowerShell.RemotingTools module" -tags CI {
+
+    It "Module should export one command" {
+        $commands = Get-Command -Module Microsoft.PowerShell.RemotingTools
+        $commands.Count | Should -BeExactly 1
+        $commands[0].Name | Should -Be "Enable-SSHRemoting"
+    }
+}


### PR DESCRIPTION
This PR creates a new Microsoft.PowerShell.RemotingTools module, that is the same as the existing PSRemotingTools module, except that it has the new, correct module name and all CI changes needed for it to successfully build/sign/test for publishing on mscodehub.