### PR TITLE
Update ci for remotingtools module

### DIFF
--- a/Modules/Microsoft.PowerShell.RemotingTools/.ci/compliance.yml
+++ b/Modules/Microsoft.PowerShell.RemotingTools/.ci/compliance.yml
@@ -14,6 +14,7 @@ steps:
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
   displayName: 'Run CredScan'
   inputs:
+    toolMajorVersion: V2
     debugMode: false
   continueOnError: true
 

--- a/Modules/Microsoft.PowerShell.RemotingTools/.ci/test.yml
+++ b/Modules/Microsoft.PowerShell.RemotingTools/.ci/test.yml
@@ -45,11 +45,11 @@ jobs:
     displayName: Execute functional tests
     errorActionPreference: continue
 
-#  - ${{ parameters.powershellExecutable }}: |
-#      Invoke-PSPackageProjectTest -Type StaticAnalysis
-#    displayName: Execute static analysis tests
-#    errorActionPreference: continue
-#    condition: succeededOrFailed()
+  - ${{ parameters.powershellExecutable }}: |
+      Invoke-PSPackageProjectTest -Type StaticAnalysis
+    displayName: Execute static analysis tests
+    errorActionPreference: continue
+    condition: succeededOrFailed()
 
   - ${{ parameters.powershellExecutable }}: |
       Unregister-PSRepository -Name 'pspackageproject-local-repo' -ErrorAction Ignore

--- a/Modules/Microsoft.PowerShell.RemotingTools/src/Microsoft.PowerShell.RemotingTools.psm1
+++ b/Modules/Microsoft.PowerShell.RemotingTools/src/Microsoft.PowerShell.RemotingTools.psm1
@@ -217,14 +217,16 @@ function CheckPowerShellVersion
     $commandToExec = "& '$FilePath' -noprofile -noninteractive -c '`$PSVersionTable.PSVersion.Major'"
     $sb = [scriptblock]::Create($commandToExec)
 
-    $psVersionMajor = 0
     try
     {
         $psVersionMajor = [int] (& $sb) 2>$null
         Write-Verbose ""
         Write-Verbose "CheckPowerShellVersion: $psVersionMajor for FilePath: $FilePath"
     }
-    catch { }
+    catch
+    {
+        $psVersionMajor = 0
+    }
 
     if ($psVersionMajor -ge 6)
     {
@@ -383,7 +385,7 @@ function Enable-SSHRemoting
     else
     {
         # macOS
-        $SSHDFound = ((launchctl list | Select-String 'com.openssh.sshd') -ne $null)
+        $SSHDFound = ($null -ne (launchctl list | Select-String 'com.openssh.sshd'))
     }
     if (! $SSHDFound)
     {


### PR DESCRIPTION
This PR updates the remotingtools module CI to use V2 of CredScan, and enable test static analysis.