### PR TITLE
Microsoft.PowerShell.RemotingTools: Enable-SSHRemoting fix Linux service status

### DIFF
--- a/Modules/Microsoft.PowerShell.RemotingTools/src/Microsoft.PowerShell.RemotingTools.psm1
+++ b/Modules/Microsoft.PowerShell.RemotingTools/src/Microsoft.PowerShell.RemotingTools.psm1
@@ -379,7 +379,7 @@ function Enable-SSHRemoting
     }
     elseif ($platformInfo.IsLinux)
     {
-        $sshdStatus = systemctl status sshd
+        $sshdStatus = sudo service ssh status
         $SSHDFound = $null -ne $sshdStatus
     }
     else


### PR DESCRIPTION
This PR changes Linux service status check to use: /usr/sbin/service instead of systemctl to check daemon service status.  The old way only works with systemd init whereas service will work for both systemd and sysvinit.